### PR TITLE
Feat: Only run styles specified in .formatter.exs on mix format

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -4,5 +4,11 @@
     "{config,lib,test}/**/*.{ex,exs}"
   ],
   plugins: [Styler],
-  line_length: 122
+  line_length: 122,
+  styles: [
+    Styler.Style.ModuleDirectives,
+    Styler.Style.Pipes,
+    Styler.Style.SingleNode,
+    Styler.Style.Defs
+  ]
 ]

--- a/README.md
+++ b/README.md
@@ -51,9 +51,19 @@ See `mix help style` for more.
 
 ### Configuration
 
-There isn't any! This is intentional.
+This Project supports minimal configuration. You can configure which styles you would like run on `mix format` by adding a `styles` key to your `.formatter.exs` file.
 
-Styler's @adobe's internal Style Guide Enforcer - allowing exceptions to the styles goes against that ethos. Happily, it's open source and thus yours to do with as you will =)
+```elixir
+# .formatter.exs
+[
+  styles: [
+    Styler.Style.ModuleDirectives,
+    Styler.Style.Pipes,
+    Styler.Style.SingleNode,
+    Styler.Style.Defs
+  ]
+]
+```
 
 ## Styles
 

--- a/test/style/defs_test.exs
+++ b/test/style/defs_test.exs
@@ -14,6 +14,7 @@ defmodule Styler.Style.DefsTest do
   describe "run" do
     test "function with do keyword" do
       assert_style(
+        Styler.Style.Defs,
         """
         # Top comment
         def save(
@@ -34,34 +35,44 @@ defmodule Styler.Style.DefsTest do
     end
 
     test "bodyless function with spec" do
-      assert_style("""
-      @spec original_object(atom()) :: atom()
-      def original_object(object)
-      """)
+      assert_style(
+        Styler.Style.Defs,
+        """
+        @spec original_object(atom()) :: atom()
+        def original_object(object)
+        """
+      )
     end
 
     test "block function body doesn't get newlined" do
-      assert_style("""
-      # Here's a comment
-      def some_function(%{id: id, type: type, processed_at: processed_at} = file, params, _)
-          when type == :file and is_nil(processed_at) do
-        with {:ok, results} <- FileProcessor.process(file) do
-          # This comment could make sense
-          {:ok, post_process_the_results_somehow(results)}
+      assert_style(
+        Styler.Style.Defs,
+        """
+        # Here's a comment
+        def some_function(%{id: id, type: type, processed_at: processed_at} = file, params, _)
+            when type == :file and is_nil(processed_at) do
+          with {:ok, results} <- FileProcessor.process(file) do
+            # This comment could make sense
+            {:ok, post_process_the_results_somehow(results)}
+          end
         end
-      end
-      """)
+        """
+      )
     end
 
     test "kwl function body doesn't get newlined" do
-      assert_style("""
-      def is_expired_timestamp?(timestamp) when is_integer(timestamp),
-        do: Timex.from_unix(timestamp, :second) <= Timex.shift(DateTime.utc_now(), minutes: 1)
-      """)
+      assert_style(
+        Styler.Style.Defs,
+        """
+        def is_expired_timestamp?(timestamp) when is_integer(timestamp),
+          do: Timex.from_unix(timestamp, :second) <= Timex.shift(DateTime.utc_now(), minutes: 1)
+        """
+      )
     end
 
     test "function with do block" do
       assert_style(
+        Styler.Style.Defs,
         """
         def save(
                %Socket{assigns: %{user: user, live_action: :new}} = initial_socket,
@@ -81,6 +92,7 @@ defmodule Styler.Style.DefsTest do
 
     test "no body" do
       assert_style(
+        Styler.Style.Defs,
         """
         # Top comment
         def no_body(
@@ -105,6 +117,7 @@ defmodule Styler.Style.DefsTest do
 
     test "when clause w kwl do" do
       assert_style(
+        Styler.Style.Defs,
         """
         def foo(%{
           bar: baz
@@ -127,6 +140,7 @@ defmodule Styler.Style.DefsTest do
 
     test "keyword do with a list" do
       assert_style(
+        Styler.Style.Defs,
         """
         def foo,
           do: [
@@ -143,6 +157,7 @@ defmodule Styler.Style.DefsTest do
 
     test "rewrites subsequent definitions" do
       assert_style(
+        Styler.Style.Defs,
         """
         def foo(), do: :ok
 
@@ -153,7 +168,7 @@ defmodule Styler.Style.DefsTest do
         ), do: :ok
         """,
         """
-        def foo, do: :ok
+        def foo(), do: :ok
 
         # Long long is too long
         def foo(too, long), do: :ok
@@ -163,6 +178,7 @@ defmodule Styler.Style.DefsTest do
 
     test "when clause with block do" do
       assert_style(
+        Styler.Style.Defs,
         """
         # Foo takes a bar
         def foo(%{
@@ -193,26 +209,32 @@ defmodule Styler.Style.DefsTest do
     end
 
     test "Doesn't move stuff around if it would make the line too long" do
-      assert_style("""
-      @doc "this is a doc"
-      # And also a comment
-      def wow_this_function_name_is_super_long(it_also, has_a, ton_of, arguments),
-        do: "this is going to end up making the line too long if we inline it"
+      assert_style(
+        Styler.Style.Defs,
+        """
+        @doc "this is a doc"
+        # And also a comment
+        def wow_this_function_name_is_super_long(it_also, has_a, ton_of, arguments),
+          do: "this is going to end up making the line too long if we inline it"
 
-      @doc "this is another function"
-      # And it also has a comment
-      def this_one_fits_on_one_line, do: :ok
-      """)
+        @doc "this is another function"
+        # And it also has a comment
+        def this_one_fits_on_one_line, do: :ok
+        """
+      )
     end
 
     test "Doesn't collapse pipe chains in a def do ... end" do
-      assert_style("""
-      def foo(some_list) do
-        some_list
-        |> Enum.reject(&is_nil/1)
-        |> Enum.map(&transform/1)
-      end
-      """)
+      assert_style(
+        Styler.Style.Defs,
+        """
+        def foo(some_list) do
+          some_list
+          |> Enum.reject(&is_nil/1)
+          |> Enum.map(&transform/1)
+        end
+        """
+      )
     end
   end
 end

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -14,24 +14,31 @@ defmodule Styler.Style.ModuleDirectivesTest do
 
   describe "defmodule features" do
     test "handles module with no directives" do
-      assert_style("""
-      defmodule Test do
-        def foo, do: :ok
-      end
-      """)
+      assert_style(
+        Styler.Style.ModuleDirectives,
+        """
+        defmodule Test do
+          def foo, do: :ok
+        end
+        """
+      )
     end
 
     test "handles dynamically generated modules" do
-      assert_style("""
-      Enum.each(testing_list, fn test_item ->
-        defmodule test_item do
-        end
-      end)
-      """)
+      assert_style(
+        Styler.Style.ModuleDirectives,
+        """
+        Enum.each(testing_list, fn test_item ->
+          defmodule test_item do
+          end
+        end)
+        """
+      )
     end
 
     test "module with single child" do
       assert_style(
+        Styler.Style.ModuleDirectives,
         """
         defmodule ATest do
           alias Foo.{A, B}
@@ -48,6 +55,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
 
     test "adds moduledoc" do
       assert_style(
+        Styler.Style.ModuleDirectives,
         """
         defmodule A do
         end
@@ -113,21 +121,28 @@ defmodule Styler.Style.ModuleDirectivesTest do
     end
 
     test "skips keyword defmodules" do
-      assert_style("defmodule Foo, do: use(Bar)")
+      assert_style(
+        Styler.Style.ModuleDirectives,
+        "defmodule Foo, do: use(Bar)"
+      )
     end
 
     test "doesn't add moduledoc to modules of specific names" do
       for verboten <- ~w(Test Mixfile Controller Endpoint Repo Router Socket View HTML JSON) do
-        assert_style("""
-        defmodule A.B.C#{verboten} do
-          @shortdoc "Don't change me!"
-        end
-        """)
+        assert_style(
+          Styler.Style.ModuleDirectives,
+          """
+          defmodule A.B.C#{verboten} do
+            @shortdoc "Don't change me!"
+          end
+          """
+        )
       end
     end
 
     test "groups directives in order" do
       assert_style(
+        Styler.Style.ModuleDirectives,
         """
         defmodule Foo do
           @behaviour Lawful
@@ -212,11 +227,14 @@ defmodule Styler.Style.ModuleDirectivesTest do
 
   describe "strange parents!" do
     test "regression: doesn't trigger on variables" do
-      assert_style("def foo(alias), do: Foo.bar(alias)")
+      assert_style(
+        Styler.Style.ModuleDirectives,
+        "def foo(alias), do: Foo.bar(alias)"
+      )
     end
 
     test "anon function" do
-      assert_style("fn -> alias A.{C, B} end", """
+      assert_style(Styler.Style.ModuleDirectives, "fn -> alias A.{C, B} end", """
       fn ->
         alias A.B
         alias A.C
@@ -226,6 +244,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
 
     test "quote do with one child" do
       assert_style(
+        Styler.Style.ModuleDirectives,
         """
         quote do
           alias A.{C, B}
@@ -241,18 +260,22 @@ defmodule Styler.Style.ModuleDirectivesTest do
     end
 
     test "quote do with multiple children" do
-      assert_style("""
-      quote do
-        import A
-        import B
-      end
-      """)
+      assert_style(
+        Styler.Style.ModuleDirectives,
+        """
+        quote do
+          import A
+          import B
+        end
+        """
+      )
     end
   end
 
   describe "directive sort/dedupe/expansion" do
     test "isn't fooled by function names" do
       assert_style(
+        Styler.Style.ModuleDirectives,
         """
         def import(foo) do
           import B
@@ -270,12 +293,16 @@ defmodule Styler.Style.ModuleDirectivesTest do
     end
 
     test "handles a lonely lonely directive" do
-      assert_style("import Foo")
+      assert_style(
+        Styler.Style.ModuleDirectives,
+        "import Foo"
+      )
     end
 
     test "sorts, dedupes & expands alias/require/import while respecting groups" do
       for d <- ~w(alias require import) do
         assert_style(
+          Styler.Style.ModuleDirectives,
           """
           #{d} D
           #{d} A.{B}
@@ -303,6 +330,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
 
     test "expands __MODULE__" do
       assert_style(
+        Styler.Style.ModuleDirectives,
         """
         alias __MODULE__.{B.D, A}
         """,
@@ -315,6 +343,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
 
     test "expands use but does not sort it" do
       assert_style(
+        Styler.Style.ModuleDirectives,
         """
         use D
         use A
@@ -337,6 +366,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
 
     test "interwoven directives w/o the context of a module" do
       assert_style(
+        Styler.Style.ModuleDirectives,
         """
         @type foo :: :ok
         alias D
@@ -363,18 +393,22 @@ defmodule Styler.Style.ModuleDirectivesTest do
     end
 
     test "respects as" do
-      assert_style("""
-      alias Foo.Asset
-      alias Foo.Project.Loaders, as: ProjectLoaders
-      alias Foo.ProjectDevice.Loaders, as: ProjectDeviceLoaders
-      alias Foo.User.Loaders
-      """)
+      assert_style(
+        Styler.Style.ModuleDirectives,
+        """
+        alias Foo.Asset
+        alias Foo.Project.Loaders, as: ProjectLoaders
+        alias Foo.ProjectDevice.Loaders, as: ProjectDeviceLoaders
+        alias Foo.User.Loaders
+        """
+      )
     end
   end
 
   describe "with comments..." do
     test "moving aliases up through non-directives doesn't move comments up" do
       assert_style(
+        Styler.Style.ModuleDirectives,
         """
         defmodule Foo do
           # mdf

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -13,17 +13,21 @@ defmodule Styler.Style.PipesTest do
 
   describe "big picture" do
     test "doesn't modify valid pipe" do
-      assert_style("""
-      a()
-      |> b()
-      |> c()
+      assert_style(
+        Styler.Style.Pipes,
+        """
+        a()
+        |> b()
+        |> c()
 
-      a |> b() |> c()
-      """)
+        a |> b() |> c()
+        """
+      )
     end
 
     test "extracts >0 arity functions" do
       assert_style(
+        Styler.Style.Pipes,
         """
         M.f(a, b)
         |> g()
@@ -40,6 +44,7 @@ defmodule Styler.Style.PipesTest do
 
     test "fixes nested pipes" do
       assert_style(
+        Styler.Style.Pipes,
         """
         a
         |> e(fn x ->
@@ -79,6 +84,7 @@ defmodule Styler.Style.PipesTest do
   describe "block pipe starts" do
     test "variable assignment of a block" do
       assert_style(
+        Styler.Style.Pipes,
         """
         x =
           case y do
@@ -103,6 +109,7 @@ defmodule Styler.Style.PipesTest do
 
     test "rewrites fors" do
       assert_style(
+        Styler.Style.Pipes,
         """
         for(a <- as, do: a)
         |> bar()
@@ -120,6 +127,7 @@ defmodule Styler.Style.PipesTest do
 
     test "rewrites unless" do
       assert_style(
+        Styler.Style.Pipes,
         """
         unless foo do
           bar
@@ -139,6 +147,7 @@ defmodule Styler.Style.PipesTest do
 
     test "rewrites with" do
       assert_style(
+        Styler.Style.Pipes,
         """
         with({:ok, value} <- foo(), do: value)
         |> bar()
@@ -156,6 +165,7 @@ defmodule Styler.Style.PipesTest do
 
     test "rewrites conds" do
       assert_style(
+        Styler.Style.Pipes,
         """
         cond do
           x -> :ok
@@ -180,6 +190,7 @@ defmodule Styler.Style.PipesTest do
 
     test "rewrites case" do
       assert_style(
+        Styler.Style.Pipes,
         """
         case x do
           x -> x
@@ -197,6 +208,7 @@ defmodule Styler.Style.PipesTest do
       )
 
       assert_style(
+        Styler.Style.Pipes,
         """
         def foo do
           case x do
@@ -220,6 +232,7 @@ defmodule Styler.Style.PipesTest do
 
     test "rewrites if" do
       assert_style(
+        Styler.Style.Pipes,
         """
         def foo do
           if true do
@@ -247,18 +260,19 @@ defmodule Styler.Style.PipesTest do
 
   describe "single pipe issues" do
     test "allows unquote single pipes" do
-      assert_style("foo |> unquote(bar)")
+      assert_style(Styler.Style.Pipes, "foo |> unquote(bar)")
     end
 
     test "fixes simple single pipes" do
-      assert_style("b(a) |> c()", "a |> b() |> c()")
-      assert_style("a |> f()", "f(a)")
-      assert_style("x |> bar", "bar(x)")
-      assert_style("def a, do: b |> c()", "def a, do: c(b)")
+      assert_style(Styler.Style.Pipes, "b(a) |> c()", "a |> b() |> c()")
+      assert_style(Styler.Style.Pipes, "a |> f()", "f(a)")
+      assert_style(Styler.Style.Pipes, "x |> bar", "bar(x)")
+      assert_style(Styler.Style.Pipes, "def a, do: b |> c()", "def a, do: c(b)")
     end
 
     test "keeps invocation on a single line" do
       assert_style(
+        Styler.Style.Pipes,
         """
         foo
         |> bar(baz, bop, boom)
@@ -269,6 +283,7 @@ defmodule Styler.Style.PipesTest do
       )
 
       assert_style(
+        Styler.Style.Pipes,
         """
         foo
         |> bar(baz)
@@ -279,6 +294,7 @@ defmodule Styler.Style.PipesTest do
       )
 
       assert_style(
+        Styler.Style.Pipes,
         """
         def halt(exec, halt_message) do
           %__MODULE__{exec | halted: true}
@@ -293,6 +309,7 @@ defmodule Styler.Style.PipesTest do
       )
 
       assert_style(
+        Styler.Style.Pipes,
         """
         if true do
           false
@@ -315,67 +332,74 @@ defmodule Styler.Style.PipesTest do
 
   describe "valid pipe starts & unpiping" do
     test "writes brackets for unpiped kwl" do
-      assert_style("foo(kwl: :arg) |> bar()", "[kwl: :arg] |> foo() |> bar()")
-      assert_style("%{a: foo(a: :b, c: :d) |> bar()}", "%{a: [a: :b, c: :d] |> foo() |> bar()}")
-      assert_style("%{a: foo([a: :b, c: :d]) |> bar()}", "%{a: [a: :b, c: :d] |> foo() |> bar()}")
+      assert_style(Styler.Style.Pipes, "foo(kwl: :arg) |> bar()", "[kwl: :arg] |> foo() |> bar()")
+      assert_style(Styler.Style.Pipes, "%{a: foo(a: :b, c: :d) |> bar()}", "%{a: [a: :b, c: :d] |> foo() |> bar()}")
+      assert_style(Styler.Style.Pipes, "%{a: foo([a: :b, c: :d]) |> bar()}", "%{a: [a: :b, c: :d] |> foo() |> bar()}")
     end
 
     test "allows fn" do
-      assert_style("""
-      fn
-        :ok -> :ok
-        :error -> :error
-      end
-      |> b()
-      |> c()
-      """)
+      assert_style(
+        Styler.Style.Pipes,
+        """
+        fn
+          :ok -> :ok
+          :error -> :error
+        end
+        |> b()
+        |> c()
+        """
+      )
     end
 
     test "recognizes infix ops as valid pipe starts" do
-      assert_style("(bar() == 1) |> foo()", "foo(bar() == 1)")
-      assert_style("(x in 1..100) |> foo()", "foo(x in 1..100)")
+      assert_style(Styler.Style.Pipes, "(bar() == 1) |> foo()", "foo(bar() == 1)")
+      assert_style(Styler.Style.Pipes, "(x in 1..100) |> foo()", "foo(x in 1..100)")
     end
 
     test "0 arity is just fine!" do
-      assert_style("foo() |> bar() |> baz()")
-      assert_style("Module.foo() |> bar() |> baz()")
+      assert_style(Styler.Style.Pipes, "foo() |> bar() |> baz()")
+      assert_style(Styler.Style.Pipes, "Module.foo() |> bar() |> baz()")
     end
 
     test "ecto funtimes" do
       for from <- ~w(from Query.from Ecto.Query.from) do
-        assert_style("""
-        #{from}(foo in Bar, where: foo.bool)
-        |> some_query_helper()
-        |> Repo.all()
-        """)
+        assert_style(
+          Styler.Style.Pipes,
+          """
+          #{from}(foo in Bar, where: foo.bool)
+          |> some_query_helper()
+          |> Repo.all()
+          """
+        )
       end
 
-      assert_style("^foo |> Ecto.Query.bar() |> Ecto.Query.baz()")
+      assert_style(Styler.Style.Pipes, "^foo |> Ecto.Query.bar() |> Ecto.Query.baz()")
     end
   end
 
   describe "simple rewrites" do
     test "rewrites anon fun def ahd invoke to use then" do
-      assert_style("a |> (& &1).()", "then(a, & &1)")
-      assert_style("a |> (& {&1, &2}).(b)", "(&{&1, &2}).(a, b)")
-      assert_style("a |> (& &1).() |> c", "a |> then(& &1) |> c()")
+      assert_style(Styler.Style.Pipes, "a |> (& &1).()", "then(a, & &1)")
+      assert_style(Styler.Style.Pipes, "a |> (& {&1, &2}).(b)", "(&{&1, &2}).(a, b)")
+      assert_style(Styler.Style.Pipes, "a |> (& &1).() |> c", "a |> then(& &1) |> c()")
 
-      assert_style("a |> (fn x, y -> {x, y} end).() |> c", "a |> then(fn x, y -> {x, y} end) |> c()")
-      assert_style("a |> (fn x -> x end).()", "then(a, fn x -> x end)")
-      assert_style("a |> (fn x -> x end).() |> c", "a |> then(fn x -> x end) |> c()")
+      assert_style(Styler.Style.Pipes, "a |> (fn x, y -> {x, y} end).() |> c", "a |> then(fn x, y -> {x, y} end) |> c()")
+      assert_style(Styler.Style.Pipes, "a |> (fn x -> x end).()", "then(a, fn x -> x end)")
+      assert_style(Styler.Style.Pipes, "a |> (fn x -> x end).() |> c", "a |> then(fn x -> x end) |> c()")
     end
 
     test "adds parens to 1-arity pipes" do
-      assert_style("a |> b |> c", "a |> b() |> c()")
+      assert_style(Styler.Style.Pipes, "a |> b |> c", "a |> b() |> c()")
     end
 
     test "reverse/concat" do
-      assert_style("a |> Enum.reverse() |> Enum.concat()")
-      assert_style("a |> Enum.reverse(bar) |> Enum.concat()")
-      assert_style("a |> Enum.reverse(bar) |> Enum.concat(foo)")
-      assert_style("a |> Enum.reverse() |> Enum.concat(foo)", "Enum.reverse(a, foo)")
+      assert_style(Styler.Style.Pipes, "a |> Enum.reverse() |> Enum.concat()")
+      assert_style(Styler.Style.Pipes, "a |> Enum.reverse(bar) |> Enum.concat()")
+      assert_style(Styler.Style.Pipes, "a |> Enum.reverse(bar) |> Enum.concat(foo)")
+      assert_style(Styler.Style.Pipes, "a |> Enum.reverse() |> Enum.concat(foo)", "Enum.reverse(a, foo)")
 
       assert_style(
+        Styler.Style.Pipes,
         """
         a
         |> Enum.reverse()
@@ -392,6 +416,7 @@ defmodule Styler.Style.PipesTest do
 
     test "filter/count" do
       assert_style(
+        Styler.Style.Pipes,
         """
         a
         |> Enum.filter(fun)
@@ -406,6 +431,7 @@ defmodule Styler.Style.PipesTest do
       )
 
       assert_style(
+        Styler.Style.Pipes,
         """
         a
         |> Enum.filter(fun)
@@ -417,6 +443,7 @@ defmodule Styler.Style.PipesTest do
       )
 
       assert_style(
+        Styler.Style.Pipes,
         """
         if true do
           []
@@ -441,6 +468,7 @@ defmodule Styler.Style.PipesTest do
 
     test "map/join" do
       assert_style(
+        Styler.Style.Pipes,
         """
         a
         |> Enum.map(b)
@@ -454,6 +482,7 @@ defmodule Styler.Style.PipesTest do
 
     test "map/into" do
       assert_style(
+        Styler.Style.Pipes,
         """
         a
         |> Enum.map(b)
@@ -463,6 +492,7 @@ defmodule Styler.Style.PipesTest do
       )
 
       assert_style(
+        Styler.Style.Pipes,
         """
         a
         |> Enum.map(b)
@@ -472,6 +502,7 @@ defmodule Styler.Style.PipesTest do
       )
 
       assert_style(
+        Styler.Style.Pipes,
         """
         a
         |> Enum.map(b)
@@ -481,6 +512,7 @@ defmodule Styler.Style.PipesTest do
       )
 
       assert_style(
+        Styler.Style.Pipes,
         """
         a
         |> Enum.map(b)
@@ -490,6 +522,7 @@ defmodule Styler.Style.PipesTest do
       )
 
       assert_style(
+        Styler.Style.Pipes,
         """
         a_multiline_mapper
         |> Enum.map(fn %{gets: shrunk, down: to_a_more_reasonable} ->
@@ -508,13 +541,14 @@ defmodule Styler.Style.PipesTest do
 
       # Regression: something about the meta wants newlines when it's in a def
       assert_style(
+        Styler.Style.Pipes,
         """
         def foo() do
           filename_map = foo |> Enum.map(&{&1.filename, true}) |> Enum.into(%{})
         end
         """,
         """
-        def foo do
+        def foo() do
           filename_map = Map.new(foo, &{&1.filename, true})
         end
         """
@@ -522,15 +556,16 @@ defmodule Styler.Style.PipesTest do
     end
 
     test "into a new map" do
-      assert_style("a |> Enum.into(foo) |> b()")
-      assert_style("a |> Enum.into(%{}) |> b()", "a |> Map.new() |> b()")
-      assert_style("a |> Enum.into(Map.new) |> b()", "a |> Map.new() |> b()")
+      assert_style(Styler.Style.Pipes, "a |> Enum.into(foo) |> b()")
+      assert_style(Styler.Style.Pipes, "a |> Enum.into(%{}) |> b()", "a |> Map.new() |> b()")
+      assert_style(Styler.Style.Pipes, "a |> Enum.into(Map.new) |> b()", "a |> Map.new() |> b()")
 
-      assert_style("a |> Enum.into(foo, mapper) |> b()")
-      assert_style("a |> Enum.into(%{}, mapper) |> b()", "a |> Map.new(mapper) |> b()")
-      assert_style("a |> Enum.into(Map.new, mapper) |> b()", "a |> Map.new(mapper) |> b()")
+      assert_style(Styler.Style.Pipes, "a |> Enum.into(foo, mapper) |> b()")
+      assert_style(Styler.Style.Pipes, "a |> Enum.into(%{}, mapper) |> b()", "a |> Map.new(mapper) |> b()")
+      assert_style(Styler.Style.Pipes, "a |> Enum.into(Map.new, mapper) |> b()", "a |> Map.new(mapper) |> b()")
 
       assert_style(
+        Styler.Style.Pipes,
         """
         a
         |> Enum.map(b)
@@ -544,6 +579,7 @@ defmodule Styler.Style.PipesTest do
       )
 
       assert_style(
+        Styler.Style.Pipes,
         """
         a
         |> Enum.map(b)

--- a/test/style/styles_test.exs
+++ b/test/style/styles_test.exs
@@ -17,6 +17,7 @@ defmodule Styler.Style.StylesTest do
   describe "pipes + defs" do
     test "pipes doesnt abuse meta and break defs" do
       assert_style(
+        [Styler.Style.Pipes, Styler.Style.Defs, Styler.Style.SingleNode],
         """
         foo
         |> bar(fn baz ->

--- a/test/support/style_case.ex
+++ b/test/support/style_case.ex
@@ -16,16 +16,16 @@ defmodule Styler.StyleCase do
 
   using do
     quote do
-      import unquote(__MODULE__), only: [assert_style: 1, assert_style: 2, style: 1]
+      import unquote(__MODULE__), only: [assert_style: 2, assert_style: 3, style: 2]
     end
   end
 
-  defmacro assert_style(before, expected \\ nil) do
+  defmacro assert_style(styles, before, expected \\ nil) do
     expected = expected || before
 
-    quote bind_quoted: [before: before, expected: expected] do
+    quote bind_quoted: [styles: styles, before: before, expected: expected], location: :keep do
       expected = String.trim(expected)
-      {styled_ast, styled, styled_comments} = style(before)
+      {styled_ast, styled, styled_comments} = style(styles, before)
 
       if styled != expected and ExUnit.configuration()[:trace] do
         IO.puts("\n======Given=============\n")
@@ -49,9 +49,9 @@ defmodule Styler.StyleCase do
     end
   end
 
-  def style(code) do
+  def style(styles, code) do
     {ast, comments} = Styler.string_to_quoted_with_comments(code)
-    {styled_ast, comments} = Styler.style({ast, comments}, "testfile", on_error: :raise)
+    {styled_ast, comments} = Styler.style({ast, comments}, List.wrap(styles), "testfile", on_error: :raise)
 
     try do
       styled_code = styled_ast |> Styler.quoted_to_string(comments) |> String.trim_trailing("\n")


### PR DESCRIPTION
Allow Users to specify the formatter rules they want applied to their codebase in `.formatter.exs`