### PR TITLE
Feat: Allow selection of styles in .formatter.exs

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -4,5 +4,11 @@
     "{config,lib,test}/**/*.{ex,exs}"
   ],
   plugins: [Styler],
-  line_length: 122
+  line_length: 122,
+  styles: [
+    Styler.Style.ModuleDirectives,
+    Styler.Style.Pipes,
+    Styler.Style.SingleNode,
+    Styler.Style.Defs
+  ]
 ]

--- a/README.md
+++ b/README.md
@@ -29,9 +29,23 @@ And that's it! Now when you run `mix format` you'll also get the benefits of Sty
 
 ### Configuration
 
-There isn't any! This is intentional.
+There isn't much! This is intentional.
 
 Styler is @adobe's internal Style Guide Enforcer - allowing exceptions to the styles goes against that ethos. Happily, it's open source and thus yours to do with as you will =)
+
+That said, this Project supports minimal configuration. You can configure, broadly, which styles you would like run on `mix format` by adding a `styles` key to your `.formatter.exs` file. By default all styles are run.
+
+```elixir
+# .formatter.exs
+[
+  styles: [
+    Styler.Style.ModuleDirectives,
+    Styler.Style.Pipes,
+    Styler.Style.SingleNode,
+    Styler.Style.Defs
+  ]
+]
+```
 
 ## Features (or as we call them, "Styles")
 

--- a/lib/styler.ex
+++ b/lib/styler.ex
@@ -25,13 +25,13 @@ defmodule Styler do
   ]
 
   @doc false
-  def style({ast, comments}, file, opts) do
+  def style({ast, comments}, styles \\ @styles, file, opts) do
     on_error = opts[:on_error] || :log
     zipper = Zipper.zip(ast)
     context = %{comments: comments, file: file}
 
     {{ast, _}, %{comments: comments}} =
-      Enum.reduce(@styles, {zipper, context}, fn style, {zipper, context} ->
+      Enum.reduce(styles, {zipper, context}, fn style, {zipper, context} ->
         try do
           Zipper.traverse_while(zipper, context, &style.run/2)
         rescue
@@ -57,11 +57,12 @@ defmodule Styler do
   @impl Mix.Tasks.Format
   def format(input, formatter_opts, opts \\ []) do
     file = formatter_opts[:file]
+    styles = Keyword.get(formatter_opts, :styles, @styles)
 
     {ast, comments} =
       input
       |> string_to_quoted_with_comments(to_string(file))
-      |> style(file, opts)
+      |> style(styles, file, opts)
 
     quoted_to_string(ast, comments, formatter_opts)
   end
@@ -93,4 +94,8 @@ defmodule Styler do
 
     IO.iodata_to_binary([formatted, ?\n])
   end
+
+  @doc false
+  # Expose the canonical list of styles for testing
+  def styles, do: @styles
 end

--- a/test/style/defs_test.exs
+++ b/test/style/defs_test.exs
@@ -153,7 +153,7 @@ defmodule Styler.Style.DefsTest do
         ), do: :ok
         """,
         """
-        def foo, do: :ok
+        def foo(), do: :ok
 
         # Long long is too long
         def foo(too, long), do: :ok

--- a/test/style/defs_test.exs
+++ b/test/style/defs_test.exs
@@ -9,7 +9,7 @@
 # governing permissions and limitations under the License.
 
 defmodule Styler.Style.DefsTest do
-  use Styler.StyleCase, async: true
+  use Styler.StyleCase, style: Styler.Style.Defs, async: true
 
   describe "run" do
     test "function with do keyword" do

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -10,7 +10,7 @@
 
 defmodule Styler.Style.ModuleDirectivesTest do
   @moduledoc false
-  use Styler.StyleCase, async: true
+  use Styler.StyleCase, style: Styler.Style.ModuleDirectives, async: true
 
   describe "defmodule features" do
     test "handles module with no directives" do

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -561,4 +561,22 @@ defmodule Styler.Style.PipesTest do
       )
     end
   end
+
+  describe "Timex.now/0,1" do
+    test "Timex.now/1 => DateTime.now!/1" do
+
+      assert_style(
+        """
+        timezone
+        |> Timex.now()
+        |> foo()
+        """,
+        """
+        timezone
+        |> DateTime.now!()
+        |> foo()
+        """
+      )
+    end
+  end
 end

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -518,7 +518,7 @@ defmodule Styler.Style.PipesTest do
         end
         """,
         """
-        def foo do
+        def foo() do
           filename_map = Map.new(foo, &{&1.filename, true})
         end
         """
@@ -564,7 +564,6 @@ defmodule Styler.Style.PipesTest do
 
   describe "Timex.now/0,1" do
     test "Timex.now/1 => DateTime.now!/1" do
-
       assert_style(
         """
         timezone

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -9,7 +9,7 @@
 # governing permissions and limitations under the License.
 
 defmodule Styler.Style.PipesTest do
-  use Styler.StyleCase, async: true
+  use Styler.StyleCase, style: Styler.Style.Pipes, async: true
 
   describe "big picture" do
     test "doesn't modify valid pipe" do

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -29,19 +29,6 @@ defmodule Styler.Style.SingleNodeTest do
 
     test "Timex.now/1 => DateTime.now!/1" do
       assert_style("Timex.now(tz)", "DateTime.now!(tz)")
-
-      assert_style(
-        """
-        timezone
-        |> Timex.now()
-        |> foo()
-        """,
-        """
-        timezone
-        |> DateTime.now!()
-        |> foo()
-        """
-      )
     end
   end
 

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -9,7 +9,7 @@
 # governing permissions and limitations under the License.
 
 defmodule Styler.Style.SingleNodeTest do
-  use Styler.StyleCase, async: true
+  use Styler.StyleCase, style: Styler.Style.SingleNode, async: true
 
   test "charlist literals: rewrites single quote charlists to ~c" do
     assert_style("'foo'", ~s|~c"foo"|)


### PR DESCRIPTION
Individual Styles can now be enabled or disabled from `formatter.exs`.  This configuration is very course and defaults to applying all styles.  

This change allows better testing of individual styles. There are a few cases where tests are making assertions outside the scope of the individual style.